### PR TITLE
1-3 メールアドレスが重複しているときに、登録できないように修正

### DIFF
--- a/src/views/RegisterAdmin.vue
+++ b/src/views/RegisterAdmin.vue
@@ -7,6 +7,7 @@
           <p v-if="firstNameError">※名を入力してください</p>
           <p v-if="mailAddressError">※メールアドレスを入力してください</p>
           <p v-if="passwordError">※パスワードを入力してください</p>
+          <p v-if="mailDuplicateError">※登録できませんでした</p>
 
           <div class="input-field col s6">
             <br />
@@ -101,6 +102,8 @@ export default class RegisterAdmin extends Vue {
   private mailAddressError = false;
   // パスワードが未入力のときのエラー
   private passwordError = false;
+  // メールアドレスが重複しているときのエラー
+  private mailDuplicateError = false;
 
   /**
    * 管理者情報を登録する.
@@ -143,8 +146,11 @@ export default class RegisterAdmin extends Vue {
       mailAddress: this.mailAddress,
       password: this.password,
     });
+    if (response.data.status == "error") {
+      this.mailDuplicateError = true;
+      return;
+    }
     console.dir("response:" + JSON.stringify(response));
-
     this.$router.push("/loginAdmin");
   }
 }


### PR DESCRIPTION
管理者登録画面でメールアドレスが既に登録済みのときに、登録できないように修正しました。
レビューお願いします。